### PR TITLE
[WIP] Import latest gem versions from rubygems.org

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,5 @@
 language: ruby
 sudo: false
-dist: trusty
-addons:
-  postgresql: "9.5"
 rvm:
   - 2.2.6
   - 2.3.3

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,8 @@
 language: ruby
 sudo: false
+dist: trusty
+addons:
+  postgresql: "9.5"
 rvm:
   - 2.2.6
   - 2.3.3

--- a/README.md
+++ b/README.md
@@ -91,6 +91,14 @@ end
   - Placeholder site for `/repositories/new`
   - Example: `github-enterprise.example.com`
 
+### Update latest gem versions
+
+```sh
+$ rails runner "GemCollector::UpdateLatestGemVersionsJob.new.perform"
+```
+
+It is better to automatic update gem_versions by a cron job at regular intervals.
+
 ## Contributing
 Contribution directions go here.
 

--- a/app/jobs/gem_collector/update_latest_gem_versions_job.rb
+++ b/app/jobs/gem_collector/update_latest_gem_versions_job.rb
@@ -1,0 +1,5 @@
+class GemCollector::UpdateLatestGemVersionsJob < GemCollector::ApplicationJob
+  def perform(*args)
+    GemCollector::UpdateLatestGemVersions.new.run
+  end
+end

--- a/app/models/gem_collector/latest_gem_version.rb
+++ b/app/models/gem_collector/latest_gem_version.rb
@@ -1,0 +1,2 @@
+class GemCollector::LatestGemVersion < GemCollector::ApplicationRecord
+end

--- a/app/services/gem_collector/update_latest_gem_versions.rb
+++ b/app/services/gem_collector/update_latest_gem_versions.rb
@@ -20,10 +20,11 @@ class GemCollector::UpdateLatestGemVersions
     def take_latest_versions(specs)
       specs.group_by(&:first).map { |name, spec|
         # spec: [gem_name, Gem::Version, platform]
+        # XXX: platform is fixed to "ruby"
+        max_version_spec = spec.select{|a| a[2] == "ruby" }.max_by{|a| a[1] }
         [
           name,
-          # XXX: platform is fixed to "ruby"
-          spec.select{|a| a[2] == "ruby" }.max_by{|a| a[1] }&.[](1)&.version
+          max_version_spec && max_version_spec[1].version
         ]
       }
     end

--- a/app/services/gem_collector/update_latest_gem_versions.rb
+++ b/app/services/gem_collector/update_latest_gem_versions.rb
@@ -1,0 +1,37 @@
+require "rubygems/remote_fetcher"
+
+class GemCollector::UpdateLatestGemVersions
+  def run
+    specs = fetch_specs
+    gem_versions = take_latest_versions(specs)
+    GemCollector::LatestGemVersion.import(
+      [:gem_name, :version],
+      gem_versions,
+      on_duplicate_key_update: { conflict_target: [:gem_name], columns: [:version] }
+    )
+  end
+
+  private
+
+    # [
+    #   [name, latest_version(or nil)],
+    #   ...
+    # ]
+    def take_latest_versions(specs)
+      specs.group_by(&:first).map { |name, spec|
+        # spec: [gem_name, Gem::Version, platform]
+        [
+          name,
+          # XXX: platform is fixed to "ruby"
+          spec.select{|a| a[2] == "ruby" }.max_by{|a| a[1] }&.[](1)&.version
+        ]
+      }
+    end
+
+    # XXX: How about prerelease_specs?
+    def fetch_specs
+      path = "https://rubygems.org/specs.#{Gem.marshal_version}.gz"
+      data = Gem::RemoteFetcher.fetcher.fetch_path(path)
+      Marshal.load(data)
+    end
+end

--- a/app/services/gem_collector/update_latest_gem_versions.rb
+++ b/app/services/gem_collector/update_latest_gem_versions.rb
@@ -4,10 +4,10 @@ class GemCollector::UpdateLatestGemVersions
   def run
     specs = fetch_specs
     gem_versions = take_latest_versions(specs)
+    GemCollector::LatestGemVersion.delete_all
     GemCollector::LatestGemVersion.import(
       [:gem_name, :version],
       gem_versions,
-      on_duplicate_key_update: { conflict_target: [:gem_name], columns: [:version] }
     )
   end
 

--- a/db/migrate/20170323181402_create_gem_collector_latest_gem_versions.rb
+++ b/db/migrate/20170323181402_create_gem_collector_latest_gem_versions.rb
@@ -1,0 +1,12 @@
+class CreateGemCollectorLatestGemVersions < ActiveRecord::Migration[5.0]
+  def change
+    create_table :gem_collector_latest_gem_versions do |t|
+      t.string :gem_name, null: false
+      t.string :version
+
+      t.timestamps
+
+      t.index :gem_name, unique: true
+    end
+  end
+end

--- a/spec/dummy/db/schema.rb
+++ b/spec/dummy/db/schema.rb
@@ -10,10 +10,18 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20170317021845) do
+ActiveRecord::Schema.define(version: 20170323181402) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
+
+  create_table "gem_collector_latest_gem_versions", force: :cascade do |t|
+    t.string   "gem_name",   null: false
+    t.string   "version"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["gem_name"], name: "index_gem_collector_latest_gem_versions_on_gem_name", unique: true, using: :btree
+  end
 
   create_table "gem_collector_repositories", force: :cascade do |t|
     t.string   "site",          null: false

--- a/spec/factories/gem_collector/latest_gem_version.rb
+++ b/spec/factories/gem_collector/latest_gem_version.rb
@@ -1,0 +1,6 @@
+FactoryGirl.define do
+  factory :latest_gem_version, class: GemCollector::LatestGemVersion do
+    sequence(:gem_name) {|n| "gem#{n}" }
+    sequence(:version)  {|n| "0.0.#{n}" }
+  end
+end

--- a/spec/services/update_latest_gem_versions_spec.rb
+++ b/spec/services/update_latest_gem_versions_spec.rb
@@ -1,0 +1,38 @@
+require 'rails_helper'
+
+RSpec.describe GemCollector::UpdateLatestGemVersions do
+  describe "#run" do
+    subject { @service.run }
+
+    before {
+      @service = GemCollector::UpdateLatestGemVersions.new
+      allow(@service).to receive(:fetch_specs) {
+        [
+          ["gem_a", Gem::Version.new("0.0.1"), "ruby"],
+          ["gem_a", Gem::Version.new("0.0.2"), "ruby"],
+          ["gem_b", Gem::Version.new("0.1.0"), "ruby"],
+          ["gem_c", Gem::Version.new("1.0.0"), "ruby"],
+        ]
+      }
+    }
+
+    context "table is empty" do
+      it "insert successfully" do
+        subject
+        actual_versions = GemCollector::LatestGemVersion.where(gem_name: %w(gem_a gem_b gem_c)).pluck(:version)
+        expect(actual_versions).to eq ["0.0.2", "0.1.0", "1.0.0"]
+      end
+    end
+
+    context "table has records" do
+      before {
+        FactoryGirl.create(:latest_gem_version, gem_name: "gem_c", version: "0.0.1")
+      }
+      it "upsert successfully" do
+        subject
+        actual_version = GemCollector::LatestGemVersion.find_by(gem_name: "gem_c").version
+        expect(actual_version).to eq "1.0.0"
+      end
+    end
+  end
+end


### PR DESCRIPTION
## What

Automaticaly update the latest version of gems.
It is useful to know it is up to date.

current:
The newest version used in the registered project in gem_collector.

Now it wants this:
The latest version on rubygems.org.

## How

1. Download `https://rubygems.org/specs.4.8.gz`.
2. Import it to `gem_collector_latest_gem_versions` table.
3. Automaticaly update it by sidekiq plug-in, whenever, vanilla cron, etc.

Like this:

```sh
rails runner "GemCollector::UpdateLatestGemVersionsJob.new.perform"
```

## Implements

Table name: latest_gem_versions

Name                      | Type               | Attributes
------------------------- | ------------------ | ---------------------------
**`id`**                  | `integer`          | `not null, primary key`
**`gem_name`**            | `string`           | `not null`
**`version`**             | `string`           |

* `index_latest_gem_versions_on_gem_name` (_unique_):
    * **`gem_name`**

`gem_name` column has unique constraint and import with `:on_duplicate_key_update` option.

## Wish to consult

* It does not fetch prerelease_specs. Is it OK?
  I think when calcurating latest gem rate, beta version should be excluded.
* gem's platform is fixed to "ruby". Is it OK?
