### PR TITLE
Do not pass nil values for Octokit >= v4.14.0

### DIFF
--- a/app/models/gem_collector/octokit_provider.rb
+++ b/app/models/gem_collector/octokit_provider.rb
@@ -1,10 +1,11 @@
 module GemCollector::OctokitProvider
   def self.get(site)
     conf = Rails.application.config.octokit.fetch(site.to_sym)
-    Octokit::Client.new(
+    options = {
       api_endpoint: conf[:api_endpoint],
       web_endpoint: conf[:web_endpoint],
       access_token: conf[:access_token],
-    )
+    }.compact
+    Octokit::Client.new(options)
   end
 end


### PR DESCRIPTION
`Octokit::Client.new(api_endpoint: nil)` is now invalid and raises
TypeError while building its API endpoint.
https://github.com/octokit/octokit.rb/pull/1091